### PR TITLE
Fix players position to table once they've joined

### DIFF
--- a/client/util.js
+++ b/client/util.js
@@ -708,13 +708,6 @@ window.AudioContext = window.AudioContext || window.webkitAudioContext;
 			var seat = root.getObjectByName('seat_'+newTurnOrder[i].id);
 			if(seat)
 			{
-				// player is already in the game, move them to position
-				/*seat.addBehavior( new Behaviors.Animate(
-					null,
-					new THREE.Vector3(-1.05*tableRadius*Math.sin(i*angle), -1.05*tableRadius*Math.cos(i*angle), 1.5),
-					new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0,0,1), -angle*i)
-				));*/
-
 				// add a kick handler if the seat was added before the current player joined
 				if( Game.playerInfo.id === newPlayerId )
 				{

--- a/client/util.js
+++ b/client/util.js
@@ -698,7 +698,7 @@ window.AudioContext = window.AudioContext || window.webkitAudioContext;
 		newTurnOrder = newTurnOrder || [];
 		oldTurnOrder = oldTurnOrder || [];
 
-		var angle = 2*Math.PI/newTurnOrder.length;
+		var angle = 2*Math.PI/12;
 		var players = newTurnOrder.map(function(e){return e.id;});
 
 		// add new players, adjust old players
@@ -709,11 +709,11 @@ window.AudioContext = window.AudioContext || window.webkitAudioContext;
 			if(seat)
 			{
 				// player is already in the game, move them to position
-				seat.addBehavior( new Behaviors.Animate(
+				/*seat.addBehavior( new Behaviors.Animate(
 					null,
 					new THREE.Vector3(-1.05*tableRadius*Math.sin(i*angle), -1.05*tableRadius*Math.cos(i*angle), 1.5),
 					new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0,0,1), -angle*i)
-				));
+				));*/
 
 				// add a kick handler if the seat was added before the current player joined
 				if( Game.playerInfo.id === newPlayerId )
@@ -734,9 +734,10 @@ window.AudioContext = window.AudioContext || window.webkitAudioContext;
 			{
 				// TODO Move most of this to seat.js
 				// create new seat for player
+				var seatNum = newTurnOrder[i].seatNum;
 				seat = new Utils.Seat(newTurnOrder[i].id, models);
-				seat.position.set(-1.05*tableRadius*Math.sin(i*angle), -1.05*tableRadius*Math.cos(i*angle), 1.5);
-				seat.rotation.set(0, 0, -angle*i);
+				seat.position.set(-1.05*tableRadius*Math.sin(seatNum*angle), -1.05*tableRadius*Math.cos(seatNum*angle), 1.5);
+				seat.rotation.set(0, 0, -angle*seatNum);
 
 				// add nameplate for the player
 				var nameplate = generateNameplate(newTurnOrder[i].displayName);
@@ -871,4 +872,3 @@ window.AudioContext = window.AudioContext || window.webkitAudioContext;
 	exports.idleCheck = idleCheck;
 	exports.idleClear = idleClear;
 })(window.Utils = window.Utils || {}, window.Models = window.Models || {}, window.Sounds = window.Sounds || {});
-

--- a/server/players.js
+++ b/server/players.js
@@ -5,7 +5,6 @@ var config = require('./config.js'),
 
 var activeGames = structs.activeGames;
 
-
 /*
  * Handle requests to join the game
  */
@@ -118,8 +117,17 @@ function join(id, displayName)
 	// subscribe client to player-only events
 	player.socket.join(game.id+'_players');
 
+	// determine correct seat for new player
+	// will be the first untaken seat in the order defined
+	var seatPriority = [0,4,8, 2,6,10, 1,5,9, 3,7,11];
+	player.seatNum = seatPriority.find(function(seat){
+		var seatIndex = game.turnOrder.findIndex(p => p.seatNum === seat);
+		return seatIndex < 0;
+	});
+
 	// add player to the end of the turn order
-	game.turnOrder.push(player);
+	var placeInTurnOrder = game.turnOrder.findIndex(p => p.seatNum > player.seatNum);
+	game.turnOrder.splice(placeInTurnOrder, 0, player);
 
 	// let other clients know about new player
 	this.server.to(game.id+'_clients').emit('playerJoin', player.id, player.displayName, game.getCleanTurnOrder());

--- a/server/structures.js
+++ b/server/structures.js
@@ -158,6 +158,7 @@ function Player(playerId, displayName, socket)
 	this.displayName = displayName;
 	this.socket = socket;
 
+	this.seatNum = null;
 	this.hand = [];
 	this.selection = null;
 	this.wins = [];
@@ -264,7 +265,7 @@ Game.prototype.getCleanTurnOrder = function()
 {
 	return this.turnOrder.map(function(cur){
 		var winCards = cur.wins.map(x => Deck.blackCardList[x]);
-		return {id: cur.id, displayName: cur.displayName, handLength: cur.handLength, wins: winCards};
+		return {id: cur.id, displayName: cur.displayName, seatNum: cur.seatNum, handLength: cur.handLength, wins: winCards};
 	});
 }
 
@@ -297,4 +298,3 @@ module.exports = {
 	// maps game ids to Game objects
 	activeGames: {}
 };
-


### PR DESCRIPTION
Instead of the players always being evenly distributed around the table, this PR causes the table to be pre-partitioned into 12 seats, and new players will join empty seats. It's much easier on Gear VR users this way.