### PR TITLE
Possible workaround for roundbreaking bug.

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -872,6 +872,7 @@ var lockIds = null;
 	function cardSelectionComplete(selections)
 	{
 		gameState = 'czarSelectionPending';
+		joinBlocked = True;
 
 		// put responses in some random order
 		var displayList = [];
@@ -1053,6 +1054,7 @@ var lockIds = null;
 	function winnerSelection(playerId)
 	{
 		gameState = 'roundFinished';
+		joinBlocked = False;
 
 		// track winner event
 		if(czarId === playerInfo.id && submissionMap[playerId].length > 0)


### PR DESCRIPTION
It seems that the game breaks when a person joins while the czar is trying to select a winner.
This should possibly block the ability to join during this time.
This is completely untested and mostly speculated from observation of the behaviour in-game and this code.